### PR TITLE
feat(Drivetrain): add questnav localization

### DIFF
--- a/src/main/kotlin/com/frcteam3636/frc2025/Diagnostics.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/Diagnostics.kt
@@ -74,7 +74,7 @@ data class Diagnostics(
             return Diagnostics(
                 batteryFull = RobotController.getBatteryVoltage() >= FULL_BATTERY_VOLTAGE,
                 navXConnected = Drivetrain.inputs.gyroConnected,
-                camerasConnected = Drivetrain.allCamerasConnected,
+                camerasConnected = Drivetrain.allPoseProvidersConnected,
                 errorStatusCodes = errorCodes,
                 canStatus = RobotController.getCANStatus(),
             )

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/AbsolutePose.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/AbsolutePose.kt
@@ -1,95 +1,121 @@
 package com.frcteam3636.frc2025.subsystems.drivetrain
 
-import edu.wpi.first.apriltag.AprilTagFieldLayout
-import edu.wpi.first.apriltag.AprilTagFields
+//import org.photonvision.PhotonCamera
+//import org.photonvision.PhotonPoseEstimator
+import com.frcteam3636.frc2025.utils.LimelightHelpers
+import com.frcteam3636.frc2025.utils.QuestNav
 import edu.wpi.first.math.Matrix
 import edu.wpi.first.math.VecBuilder
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator
+import edu.wpi.first.math.geometry.Pose2d
 import edu.wpi.first.math.geometry.Pose3d
-import edu.wpi.first.math.geometry.Rotation3d
-import edu.wpi.first.math.geometry.Translation3d
 import edu.wpi.first.math.numbers.N1
 import edu.wpi.first.math.numbers.N3
-import edu.wpi.first.math.util.Units
-import edu.wpi.first.networktables.NetworkTableInstance
-import edu.wpi.first.units.Units.DegreesPerSecond
+import edu.wpi.first.units.Units.Meters
+import edu.wpi.first.units.Units.Seconds
+import edu.wpi.first.units.measure.Time
 import edu.wpi.first.util.struct.Struct
 import edu.wpi.first.util.struct.StructSerializable
+import edu.wpi.first.wpilibj.Alert
+import edu.wpi.first.wpilibj.Alert.AlertType
 import edu.wpi.first.wpilibj.Timer
 import org.littletonrobotics.junction.LogTable
-import org.littletonrobotics.junction.Logger
 import org.littletonrobotics.junction.inputs.LoggableInputs
-//import org.photonvision.PhotonCamera
-//import org.photonvision.PhotonPoseEstimator
+import org.team9432.annotation.Logged
 import java.nio.ByteBuffer
-import kotlin.math.pow
 
-interface AbsolutePoseIO {
-    class Inputs : LoggableInputs {
-        // The most recent measurement from the pose estimator.
-        var measurement: AbsolutePoseMeasurement? = null
+class AbsolutePoseProviderInputs : LoggableInputs {
+    /**
+     * The most recent measurement from the pose estimator.
+     */
+    var measurement: AbsolutePoseMeasurement? = null
 
-        override fun toLog(table: LogTable) {
-//            if (measurement != null) {
-//                table.put("Measurement", measurement)
-//            }
+    /**
+     * If there is little to no ambiguity.
+     */
+    var isHighQualityReading = false
+
+    /**
+     * Whether the provider is connected.
+     */
+    var connected = false
+
+    override fun toLog(table: LogTable) {
+        if (measurement != null) {
+            table.put("Measurement", measurement)
         }
-
-        override fun fromLog(table: LogTable?) {
-//            measurement = table?.get("Measurement", measurement)!![0]
-        }
+        table.put("Connected", connected)
     }
 
-    fun updateInputs(inputs: Inputs)
-
-    val cameraConnected: Boolean
+    override fun fromLog(table: LogTable) {
+        measurement = table.get("Measurement", measurement)[0]
+        connected = table.get("Connected", connected)
+    }
 }
 
-class LimelightPoseIOReal(private val name: String) : AbsolutePoseIO {
-    private val table = NetworkTableInstance
-        .getDefault()
-        .getTable(name)
-    private val stddev = VecBuilder.fill(.7, .7, 9999999.0)
 
-    private val botPose = table.getDoubleArrayTopic("botpose_wpiblue").subscribe(null)
-    private val cl = table.getDoubleTopic("cl").subscribe(0.0)
-    private val tl = table.getDoubleTopic("tl").subscribe(0.0)
-    private val disconnectTimeout = Timer().apply {
-        start()
-    }
+interface AbsolutePoseProvider {
+    fun updateInputs(inputs: AbsolutePoseProviderInputs)
+}
 
-    override fun updateInputs(inputs: AbsolutePoseIO.Inputs) {
-        inputs.measurement = botPose.readQueue().lastOrNull()?.let { update ->
+class LimelightPoseProvider(private val name: String) : AbsolutePoseProvider {
+    override fun updateInputs(inputs: AbsolutePoseProviderInputs) {
+        // This is mostly pulled from the LimeLight docs.
+        // https://docs.limelightvision.io/docs/docs-limelight/apis/limelight-lib#4-field-localization-with-megatag
+        val estimate = LimelightHelpers.getBotPoseEstimate_wpiBlue(name)
+        val trackedTag = LimelightHelpers.getTargetPose3d_RobotSpace(name)
 
-            val x = update.value[0]
-            val y = update.value[1]
-            val z = update.value[2]
-            val roll = Units.degreesToRadians(update.value[3])
-            val pitch = Units.degreesToRadians(update.value[4])
-            val yaw = Units.degreesToRadians(update.value[5])
-            val tagCount = update.value[7]
-
-            disconnectTimeout.restart()
-
-            if (tagCount == 0.0 || Drivetrain.gyroRate > DegreesPerSecond.of(720.0)) {
-                return
-            }
-
-            val latency = cl.get() + tl.get()
-
+        // Only trust the measurement if we see multiple tags.
+        inputs.measurement = if (estimate != null && estimate.tagCount >= 2) {
             AbsolutePoseMeasurement(
-                pose = Pose3d(Translation3d(x, y, z), Rotation3d(roll, pitch, yaw)),
-                timestamp = (update.timestamp * 1e-6) - (latency * 1e-3),
-                stdDeviation = stddev
-            ).also {
-                Logger.recordOutput("Absolute Pose/$name/Pose", it.pose)
-                Logger.recordOutput("Absolute Pose/$name/Tag Count", tagCount)
-            }
+                estimate.pose,
+                Seconds.of(estimate.timestampSeconds),
+                VecBuilder.fill(0.7, 0.7, 9999999.0),
+            )
+        } else {
+            null
         }
+
+        val hasReading = (estimate?.tagCount ?: 0) >= 1
+        val readingIsNearby = trackedTag.translation.norm < DISTANT_APRIL_TAG_DISTANCE.`in`(Meters)
+        inputs.isHighQualityReading = hasReading && readingIsNearby
+
+        // We assume the camera has disconnected if there's no new updates.
+        inputs.connected = inputs.measurement?.let {
+            val timeSinceLastUpdate = Seconds.of(Timer.getTimestamp()) - it.timestamp
+            timeSinceLastUpdate > Seconds.of(0.25)
+        } ?: false
+    }
+}
+
+@Logged
+open class QuestNavInputs {
+    /**
+     * The most recent measurement from the Quest.
+     */
+    var pose = Pose2d()
+
+    /**
+     * Whether the provider is connected.
+     */
+    var connected = false
+}
+
+class QuestNavLocalizer {
+    private val questNav = QuestNav()
+    private val lowBatteryAlert = Alert("The Meta Quest battery is below 20%!", AlertType.kWarning)
+
+    fun resetPose(pose: Pose2d) {
+        questNav.resetPosition(pose)
     }
 
-    override val cameraConnected
-        get() = disconnectTimeout.hasElapsed(1.0)
+    fun updateInputs(inputs: QuestNavInputs) {
+        questNav.finalizeCommands()
+        lowBatteryAlert.set(questNav.batteryPercent < 20.0)
+
+        inputs.connected = questNav.connected
+        inputs.pose = questNav.pose
+    }
 }
 
 //@Suppress("unused")
@@ -118,8 +144,15 @@ class LimelightPoseIOReal(private val name: String) : AbsolutePoseIO {
 //        get() = camera.isConnected
 //}
 
-data class AbsolutePoseMeasurement(val pose: Pose3d, val timestamp: Double, val stdDeviation: Matrix<N3, N1>) :
-    StructSerializable {
+data class AbsolutePoseMeasurement(
+    val pose: Pose2d,
+    val timestamp: Time,
+    /**
+     * Standard deviations of the vision pose measurement (x position in meters, y position in meters, and heading in
+     * radians). Increase these numbers to trust the vision pose measurement less.
+     */
+    val stdDeviation: Matrix<N3, N1>
+) : StructSerializable {
     companion object {
         @JvmField
         @Suppress("unused")
@@ -129,9 +162,9 @@ data class AbsolutePoseMeasurement(val pose: Pose3d, val timestamp: Double, val 
 
 fun SwerveDrivePoseEstimator.addAbsolutePoseMeasurement(measurement: AbsolutePoseMeasurement) {
     addVisionMeasurement(
-        measurement.pose.toPose2d(),
-        measurement.timestamp,
-//        measurement.stdDeviation // seems to fire the bot into orbit
+        measurement.pose,
+        measurement.timestamp.`in`(Seconds),
+        measurement.stdDeviation // FIXME: seems to fire the bot into orbit...?
     )
 }
 
@@ -143,32 +176,33 @@ class AbsolutePoseMeasurementStruct : Struct<AbsolutePoseMeasurement> {
 
     override fun getTypeString(): String = "struct:AbsolutePoseMeasurement"
     override fun getSize(): Int = Pose3d.struct.size + Struct.kSizeDouble + 3 * Struct.kSizeDouble
-    override fun getSchema(): String = "Pose3d pose; double timestamp; double stdDeviation[3];"
+    override fun getSchema(): String = "Pose2d pose; double timestamp; double stdDeviation[3];"
     override fun unpack(bb: ByteBuffer): AbsolutePoseMeasurement =
         AbsolutePoseMeasurement(
-            pose = Pose3d.struct.unpack(bb),
-            timestamp = bb.double,
+            pose = Pose2d.struct.unpack(bb),
+            timestamp = Seconds.of(bb.double),
             stdDeviation = VecBuilder.fill(bb.double, bb.double, bb.double)
         )
 
     override fun pack(bb: ByteBuffer, value: AbsolutePoseMeasurement) {
-        Pose3d.struct.pack(bb, value.pose)
-        bb.putDouble(value.timestamp)
+        Pose2d.struct.pack(bb, value.pose)
+        bb.putDouble(value.timestamp.`in`(Seconds))
         bb.putDouble(value.stdDeviation[0, 0])
         bb.putDouble(value.stdDeviation[1, 0])
         bb.putDouble(value.stdDeviation[2, 0])
     }
 }
 
-internal val APRIL_TAG_FIELD_LAYOUT = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2024Crescendo.m_resourceFile)
+//internal val APRIL_TAG_FIELD_LAYOUT = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2024Crescendo.m_resourceFile)
 
-@Suppress("unused")
-internal const val APRIL_TAG_AMBIGUITY_FILTER = 0.3
-internal val APRIL_TAG_STD_DEV = { distance: Double, count: Int ->
-    val distanceMultiplier = (distance - (count - 1) * 3).pow(2.0)
-    val translationalStdDev = (0.05 / count) * distanceMultiplier + 0.0
-    val rotationalStdDev = 0.2 * distanceMultiplier + 0.1
-    VecBuilder.fill(
-        translationalStdDev, translationalStdDev, rotationalStdDev
-    )
-}
+//internal const val APRIL_TAG_AMBIGUITY_FILTER = 0.3
+//internal val APRIL_TAG_STD_DEV = { distance: Double, count: Int ->
+//    val distanceMultiplier = (distance - (count - 1) * 3).pow(2.0)
+//    val translationalStdDev = (0.05 / count) * distanceMultiplier + 0.0
+//    val rotationalStdDev = 0.2 * distanceMultiplier + 0.1
+//    VecBuilder.fill(
+//        translationalStdDev, translationalStdDev, rotationalStdDev
+//    )
+//}
+
+val DISTANT_APRIL_TAG_DISTANCE = Meters.of(6.0)!!

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/AbsolutePose.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/AbsolutePose.kt
@@ -9,6 +9,8 @@ import edu.wpi.first.math.VecBuilder
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator
 import edu.wpi.first.math.geometry.Pose2d
 import edu.wpi.first.math.geometry.Pose3d
+import edu.wpi.first.math.geometry.Transform2d
+import edu.wpi.first.math.geometry.Transform3d
 import edu.wpi.first.math.numbers.N1
 import edu.wpi.first.math.numbers.N3
 import edu.wpi.first.units.Units.Meters
@@ -101,9 +103,15 @@ open class QuestNavInputs {
     var connected = false
 }
 
-class QuestNavLocalizer {
+class QuestNavLocalizer(
+    /**
+     * The location of the QuestNav device relative to the robot chassis.
+     */
+    deviceOffset: Transform2d,
+) {
     private val questNav = QuestNav()
-    private val lowBatteryAlert = Alert("The Meta Quest battery is below 20%!", AlertType.kWarning)
+    private val lowBatteryAlert = Alert("The Meta Quest battery is below 40%!", AlertType.kWarning)
+    private val deviceToChassis = deviceOffset.inverse()
 
     fun resetPose(pose: Pose2d) {
         questNav.resetPosition(pose)
@@ -111,10 +119,10 @@ class QuestNavLocalizer {
 
     fun updateInputs(inputs: QuestNavInputs) {
         questNav.finalizeCommands()
-        lowBatteryAlert.set(questNav.batteryPercent < 20.0)
+        lowBatteryAlert.set(questNav.batteryPercent < 40.0)
 
         inputs.connected = questNav.connected
-        inputs.pose = questNav.pose
+        inputs.pose = questNav.pose.transformBy(deviceToChassis)
     }
 }
 

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/AbsolutePose.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/AbsolutePose.kt
@@ -22,6 +22,7 @@ import edu.wpi.first.wpilibj.Alert
 import edu.wpi.first.wpilibj.Alert.AlertType
 import edu.wpi.first.wpilibj.Timer
 import org.littletonrobotics.junction.LogTable
+import org.littletonrobotics.junction.Logger
 import org.littletonrobotics.junction.inputs.LoggableInputs
 import org.team9432.annotation.Logged
 import java.nio.ByteBuffer
@@ -31,11 +32,6 @@ class AbsolutePoseProviderInputs : LoggableInputs {
      * The most recent measurement from the pose estimator.
      */
     var measurement: AbsolutePoseMeasurement? = null
-
-    /**
-     * If there is little to no ambiguity.
-     */
-    var isHighQualityReading = false
 
     /**
      * Whether the provider is connected.
@@ -58,6 +54,11 @@ class AbsolutePoseProviderInputs : LoggableInputs {
 
 interface AbsolutePoseProvider {
     fun updateInputs(inputs: AbsolutePoseProviderInputs)
+
+    /**
+     * If there is little to no ambiguity.
+     */
+    val hasHighQualityReading: Boolean
 }
 
 class LimelightPoseProvider(private val name: String) : AbsolutePoseProvider {
@@ -80,7 +81,7 @@ class LimelightPoseProvider(private val name: String) : AbsolutePoseProvider {
 
         val hasReading = (estimate?.tagCount ?: 0) >= 1
         val readingIsNearby = trackedTag.translation.norm < DISTANT_APRIL_TAG_DISTANCE.`in`(Meters)
-        inputs.isHighQualityReading = hasReading && readingIsNearby
+        hasHighQualityReading = hasReading && readingIsNearby
 
         // We assume the camera has disconnected if there's no new updates.
         inputs.connected = inputs.measurement?.let {
@@ -88,6 +89,9 @@ class LimelightPoseProvider(private val name: String) : AbsolutePoseProvider {
             timeSinceLastUpdate > Seconds.of(0.25)
         } ?: false
     }
+
+    override var hasHighQualityReading = false
+        private set
 }
 
 @Logged

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Drivetrain.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Drivetrain.kt
@@ -1,8 +1,5 @@
 package com.frcteam3636.frc2025.subsystems.drivetrain
 
-//import com.frcteam3636.frc2024.subsystems.drivetrain.Drivetrain.Constants.DEFAULT_PATHING_CONSTRAINTS
-//import com.pathplanner.lib.util.HolonomicPathFollowerConfig
-//import com.pathplanner.lib.util.ReplanningConfig
 import com.frcteam3636.frc2025.CTREDeviceId
 import com.frcteam3636.frc2025.REVMotorControllerId
 import com.frcteam3636.frc2025.Robot
@@ -56,7 +53,7 @@ object Drivetrain : Subsystem, Sendable {
     }
     val inputs = LoggedDrivetrainInputs()
 
-    private val questNavInactiveAlert = Alert("QuestNav is inactive.", Alert.AlertType.kInfo)
+    private val questNavInactiveAlert = Alert("QuestNav localizer is not active.", Alert.AlertType.kInfo)
 
     private val questNavLocalizer = QuestNavLocalizer(Constants.QUESTNAV_DEVICE_OFFSET)
     private val questNavInputs = LoggedQuestNavInputs()
@@ -140,6 +137,7 @@ object Drivetrain : Subsystem, Sendable {
                 Logger.recordOutput("Drivetrain/Last Added Pose", it.pose)
                 Logger.recordOutput("Drivetrain/Absolute Pose/$name/Pose", it.pose)
             }
+            Logger.recordOutput("Drivetrain/Absolute Pose/$name/Has High Quality Reading", sensorIO.hasHighQualityReading)
         }
 
         // Use the new measurements to update the pose estimator
@@ -223,7 +221,7 @@ object Drivetrain : Subsystem, Sendable {
      */
     private fun updateQuestNavOrigin() {
         val hasHighQualityData = absolutePoseIOs.values.any {
-            it.second.isHighQualityReading
+            it.first.hasHighQualityReading
         }
         if (!hasHighQualityData || isMoving) return
         questNavLocalizer.resetPose(poseEstimator.estimatedPosition)

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Drivetrain.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Drivetrain.kt
@@ -26,10 +26,7 @@ import com.pathplanner.lib.controllers.PPHolonomicDriveController
 import com.pathplanner.lib.pathfinding.Pathfinding
 import edu.wpi.first.math.VecBuilder
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator
-import edu.wpi.first.math.geometry.Pose2d
-import edu.wpi.first.math.geometry.Rotation2d
-import edu.wpi.first.math.geometry.Rotation3d
-import edu.wpi.first.math.geometry.Translation2d
+import edu.wpi.first.math.geometry.*
 import edu.wpi.first.math.kinematics.ChassisSpeeds
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics
 import edu.wpi.first.math.kinematics.SwerveModuleState
@@ -61,7 +58,7 @@ object Drivetrain : Subsystem, Sendable {
 
     private val questNavInactiveAlert = Alert("QuestNav is inactive.", Alert.AlertType.kInfo)
 
-    private val questNavLocalizer = QuestNavLocalizer()
+    private val questNavLocalizer = QuestNavLocalizer(Constants.QUESTNAV_DEVICE_OFFSET)
     private val questNavInputs = LoggedQuestNavInputs()
     private var questNavCalibrated = false
 
@@ -464,6 +461,13 @@ object Drivetrain : Subsystem, Sendable {
 
         /** A position with the modules radiating outwards from the center of the robot, preventing movement. */
         val BRAKE_POSITION = MODULE_POSITIONS.map { position -> SwerveModuleState(0.0, position.translation.angle) }
+
+        val QUESTNAV_DEVICE_OFFSET = Transform2d(
+            // TODO: find these constants
+            Inches.of(0.0),
+            Inches.of(0.0),
+            Rotation2d(Degrees.of(0.0))
+        )
     }
 
     enum class Localizer {

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Drivetrain.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Drivetrain.kt
@@ -1,29 +1,29 @@
 package com.frcteam3636.frc2025.subsystems.drivetrain
 
+//import com.frcteam3636.frc2024.subsystems.drivetrain.Drivetrain.Constants.DEFAULT_PATHING_CONSTRAINTS
+//import com.pathplanner.lib.util.HolonomicPathFollowerConfig
+//import com.pathplanner.lib.util.ReplanningConfig
 import com.frcteam3636.frc2025.CTREDeviceId
 import com.frcteam3636.frc2025.REVMotorControllerId
 import com.frcteam3636.frc2025.Robot
 import com.frcteam3636.frc2025.subsystems.drivetrain.Drivetrain.Constants.BRAKE_POSITION
-//import com.frcteam3636.frc2024.subsystems.drivetrain.Drivetrain.Constants.DEFAULT_PATHING_CONSTRAINTS
 import com.frcteam3636.frc2025.subsystems.drivetrain.Drivetrain.Constants.FREE_SPEED
 import com.frcteam3636.frc2025.subsystems.drivetrain.Drivetrain.Constants.JOYSTICK_DEADBAND
 import com.frcteam3636.frc2025.subsystems.drivetrain.Drivetrain.Constants.ROTATION_PID_GAINS
 import com.frcteam3636.frc2025.subsystems.drivetrain.Drivetrain.Constants.ROTATION_SENSITIVITY
 import com.frcteam3636.frc2025.subsystems.drivetrain.Drivetrain.Constants.TRANSLATION_SENSITIVITY
 import com.frcteam3636.frc2025.utils.ElasticWidgets
-import com.frcteam3636.frc2025.utils.math.*
-import com.frcteam3636.frc2025.utils.swerve.PerCorner
-import com.frcteam3636.frc2025.utils.swerve.cornerStatesToChassisSpeeds
-import com.frcteam3636.frc2025.utils.swerve.toCornerSwerveModuleStates
+import com.frcteam3636.frc2025.utils.math.PIDController
+import com.frcteam3636.frc2025.utils.math.PIDGains
+import com.frcteam3636.frc2025.utils.math.TAU
+import com.frcteam3636.frc2025.utils.math.toPPLib
+import com.frcteam3636.frc2025.utils.swerve.*
 import com.frcteam3636.frc2025.utils.translation2d
 import com.pathplanner.lib.auto.AutoBuilder
 import com.pathplanner.lib.config.ModuleConfig
 import com.pathplanner.lib.config.RobotConfig
 import com.pathplanner.lib.controllers.PPHolonomicDriveController
-import com.pathplanner.lib.controllers.PPLTVController
 import com.pathplanner.lib.pathfinding.Pathfinding
-//import com.pathplanner.lib.util.HolonomicPathFollowerConfig
-//import com.pathplanner.lib.util.ReplanningConfig
 import edu.wpi.first.math.VecBuilder
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator
 import edu.wpi.first.math.geometry.Pose2d
@@ -35,13 +35,10 @@ import edu.wpi.first.math.kinematics.SwerveDriveKinematics
 import edu.wpi.first.math.kinematics.SwerveModuleState
 import edu.wpi.first.math.system.plant.DCMotor
 import edu.wpi.first.math.util.Units
-import edu.wpi.first.units.TimeUnit
 import edu.wpi.first.units.Units.*
-import edu.wpi.first.units.measure.AngularVelocity
-import edu.wpi.first.units.measure.Mass
-import edu.wpi.first.units.measure.MomentOfInertia
 import edu.wpi.first.util.sendable.Sendable
 import edu.wpi.first.util.sendable.SendableBuilder
+import edu.wpi.first.wpilibj.Alert
 import edu.wpi.first.wpilibj.DriverStation
 import edu.wpi.first.wpilibj.Joystick
 import edu.wpi.first.wpilibj2.command.Command
@@ -62,11 +59,15 @@ object Drivetrain : Subsystem, Sendable {
     }
     val inputs = LoggedDrivetrainInputs()
 
+    private val questNavInactiveAlert = Alert("QuestNav is inactive.", Alert.AlertType.kInfo)
+
+    private val questNavLocalizer = QuestNavLocalizer()
+    private val questNavInputs = LoggedQuestNavInputs()
+    private var questNavCalibrated = false
+
     private val absolutePoseIOs = mapOf(
-        "Limelight" to LimelightPoseIOReal(
-            "limelight",
-        )
-    ).mapValues { Pair(it.value, AbsolutePoseIO.Inputs()) }
+        "Limelight" to LimelightPoseProvider("limelight"),
+    ).mapValues { Pair(it.value, AbsolutePoseProviderInputs()) }
 
     /** Helper for converting a desired drivetrain velocity into the speeds and angles for each swerve module */
     private val kinematics =
@@ -85,12 +86,18 @@ object Drivetrain : Subsystem, Sendable {
             VecBuilder.fill(0.5, 0.5, Units.degreesToRadians(10.0))
         )
 
-    /** Whether every camera used for pose estimation is connected. */
-    val allCamerasConnected
-        get() = absolutePoseIOs.values.all { it.first.cameraConnected }
+    /** Whether every sensor used for pose estimation is connected. */
+    val allPoseProvidersConnected
+        get() = absolutePoseIOs.values.all { it.second.connected }
 
-    var gyroRate = RadiansPerSecond.zero()!!
-        private set
+    val isMoving: Boolean
+        get() {
+            val speeds = measuredChassisSpeeds
+            val translationalSpeed = MetersPerSecond.of(speeds.translation2dPerSecond.norm)
+            return translationalSpeed < MetersPerSecond.of(0.5)
+                    && speeds.angularVelocity < RotationsPerSecond.of(0.5)
+        }
+
 
     init {
         Pathfinding.setPathfinder(
@@ -120,12 +127,8 @@ object Drivetrain : Subsystem, Sendable {
     }
 
     override fun periodic() {
-        val previousGyro = inputs.gyroRotation.toRotation2d().angle
-
         io.updateInputs(inputs)
         Logger.processInputs("Drivetrain", inputs)
-
-        gyroRate = (inputs.gyroRotation.toRotation2d().angle - previousGyro) / Seconds.of(Robot.period)
 
         // Update absolute pose sensors and add their measurements to the pose estimator
         for ((name, ioPair) in absolutePoseIOs) {
@@ -147,8 +150,17 @@ object Drivetrain : Subsystem, Sendable {
             inputs.gyroRotation.toRotation2d(),
             inputs.measuredPositions.toTypedArray()
         )
+
+        questNavLocalizer.updateInputs(questNavInputs)
+        Logger.processInputs("Drivetrain/QuestNav", questNavInputs)
+        updateQuestNavOrigin()
+
+        Logger.recordOutput("Drivetrain/QuestNav/Calibrated", questNavCalibrated)
+        Logger.recordOutput("Drivetrain/Pose Estimator/Estimated Pose", poseEstimator.estimatedPosition)
         Logger.recordOutput("Drivetrain/Estimated Pose", estimatedPose)
         Logger.recordOutput("Drivetrain/Chassis Speeds", measuredChassisSpeeds)
+        Logger.recordOutput("Drivetrain/Localizer", localizer.name)
+        questNavInactiveAlert.set(localizer != Localizer.QuestNav)
     }
 
     /** The desired speeds and angles of the swerve modules. */
@@ -182,10 +194,21 @@ object Drivetrain : Subsystem, Sendable {
             desiredModuleStates = kinematics.toCornerSwerveModuleStates(discretized)
         }
 
+    val localizer: Localizer
+        get() = if (questNavCalibrated && questNavInputs.connected) {
+            Localizer.QuestNav
+        } else {
+            Localizer.PoseEstimator
+        }
+
     /** The estimated pose of the robot on the field, using the yaw value measured by the gyro. */
     var estimatedPose: Pose2d
         get() {
-            val estimated = poseEstimator.estimatedPosition
+            val estimated = when (localizer) {
+                Localizer.QuestNav -> questNavInputs.pose
+                Localizer.PoseEstimator -> poseEstimator.estimatedPosition
+            }
+
             return Pose2d(
                 estimated.x,
                 estimated.y,
@@ -197,6 +220,18 @@ object Drivetrain : Subsystem, Sendable {
             inputs.measuredPositions.toTypedArray(),
             value
         )
+
+    /**
+     * Update the QuestNav pose to keep its origin correct.
+     */
+    private fun updateQuestNavOrigin() {
+        val hasHighQualityData = absolutePoseIOs.values.any {
+            it.second.isHighQualityReading
+        }
+        if (!hasHighQualityData || isMoving) return
+        questNavLocalizer.resetPose(poseEstimator.estimatedPosition)
+        questNavCalibrated = true
+    }
 
     override fun initSendable(builder: SendableBuilder) {
         builder.setSmartDashboardType(ElasticWidgets.SwerveDrive.widgetName)
@@ -247,7 +282,7 @@ object Drivetrain : Subsystem, Sendable {
             drive(translationInput, rotationInput)
         }
 
-    private val rotationPIDController = PIDController(Constants.ROTATION_PID_GAINS).apply {
+    private val rotationPIDController = PIDController(ROTATION_PID_GAINS).apply {
         enableContinuousInput(0.0, TAU)
     }
 
@@ -429,5 +464,10 @@ object Drivetrain : Subsystem, Sendable {
 
         /** A position with the modules radiating outwards from the center of the robot, preventing movement. */
         val BRAKE_POSITION = MODULE_POSITIONS.map { position -> SwerveModuleState(0.0, position.translation.angle) }
+    }
+
+    enum class Localizer {
+        QuestNav,
+        PoseEstimator,
     }
 }

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Gyro.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Gyro.kt
@@ -43,7 +43,7 @@ class GyroNavX(private val ahrs: AHRS) : Gyro {
         get() = ahrs.isConnected
 }
 
-class  GyroPigeon(private val pigeon: Pigeon2) : Gyro {
+class GyroPigeon(private val pigeon: Pigeon2) : Gyro {
 
     private var offset: Rotation3d = Rotation3d()
 

--- a/src/main/kotlin/com/frcteam3636/frc2025/utils/QuestNav.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/utils/QuestNav.kt
@@ -1,0 +1,156 @@
+package com.frcteam3636.frc2025.utils
+
+import edu.wpi.first.math.geometry.Pose2d
+import edu.wpi.first.math.geometry.Quaternion
+import edu.wpi.first.math.geometry.Rotation2d
+import edu.wpi.first.math.geometry.Translation2d
+import edu.wpi.first.networktables.DoubleSubscriber
+import edu.wpi.first.networktables.FloatArraySubscriber
+import edu.wpi.first.networktables.NetworkTable
+import edu.wpi.first.networktables.NetworkTableInstance
+import edu.wpi.first.units.Units.Seconds
+import edu.wpi.first.units.measure.Time
+import edu.wpi.first.wpilibj.RobotController
+import edu.wpi.first.wpilibj.Timer
+
+enum class QuestCommand(val id: Long) {
+    /**
+     * A value that represents the lack of a command.
+     */
+    None(0),
+
+    /**
+     * Recenters the player's view by adjusting the VR camera root transform to match the reset transform.
+     * Similar to the effect of long-pressing the Oculus button.
+     */
+    HeadingRecenter(1),
+
+    /**
+     * Initiates a pose reset based on received NetworkTables data
+     */
+    PoseReset(2),
+
+    /**
+     * Responds with [PING_RESPONSE].
+     */
+    Ping(3)
+}
+
+const val COMMAND_NEEDS_FINALIZATION = 99L
+const val PING_RESPONSE = 97L
+
+class QuestNav {
+    // Configure Network Tables topics (questnav/...) to communicate with the Quest HMD
+    var nt4Instance: NetworkTableInstance = NetworkTableInstance.getDefault()
+    var nt4Table: NetworkTable = nt4Instance.getTable("questnav")
+
+    private val receiver = nt4Table.getIntegerTopic("miso").subscribe(0)
+    private val transmitter = nt4Table.getIntegerTopic("mosi").publish()
+    private val questResetPose = nt4Table.getDoubleArrayTopic("resetpose").publish()
+
+    // Subscribe to the Network Tables questnav data topics
+    private val questTimestamp: DoubleSubscriber = nt4Table.getDoubleTopic("timestamp").subscribe(0.0)
+    private val questPosition: FloatArraySubscriber =
+        nt4Table.getFloatArrayTopic("position").subscribe(floatArrayOf(0.0f, 0.0f, 0.0f))
+    private val questQuaternion: FloatArraySubscriber =
+        nt4Table.getFloatArrayTopic("quaternion").subscribe(floatArrayOf(0.0f, 0.0f, 0.0f, 0.0f))
+    private val questEulerAngles: FloatArraySubscriber = nt4Table.getFloatArrayTopic("eulerAngles").subscribe(
+        floatArrayOf(0.0f, 0.0f, 0.0f)
+    )
+    private val questBatteryPercent: DoubleSubscriber = nt4Table.getDoubleTopic("batteryPercent").subscribe(0.0)
+
+    private var timestampEpoch: Time? = null
+
+    /**
+     * The Quest's measured position.
+     */
+    val pose: Pose2d
+        get() = Pose2d(questNavPose.translation, Rotation2d.fromDegrees(oculusYaw.toDouble()))
+
+    /**
+     * The battery percent of the Quest.
+     */
+    val batteryPercent: Double
+        get() = questBatteryPercent.get()
+
+    /** If the Quest is connected. */
+    val connected: Boolean
+        get() = ((RobotController.getFPGATime() - questBatteryPercent.lastChange) / 1000) < 250
+
+    /** The Quaternion of the Quest. */
+    val quaternion: Quaternion
+        get() {
+            val qqFloats = questQuaternion.get()
+            return Quaternion(
+                qqFloats[0].toDouble(),
+                qqFloats[1].toDouble(),
+                qqFloats[2].toDouble(),
+                qqFloats[3].toDouble()
+            )
+        }
+
+    /** The Quests's timestamp. */
+    val timestamp: Time
+        get() {
+            // Make sure our timestamp epochs are the same.
+            val rawTimestamp = Seconds.of(questTimestamp.get())
+            if (rawTimestamp != Seconds.zero()) {
+                if (timestampEpoch == null) {
+                    timestampEpoch = Seconds.of(Timer.getTimestamp()) - rawTimestamp
+                }
+                return rawTimestamp + timestampEpoch
+            }
+            return Seconds.zero()
+        }
+
+    /**
+     * Sends a command to the Quest.
+     * @return `true` if the command was sent, `false` if the Quest was busy.
+     */
+    private fun sendCommand(command: QuestCommand): Boolean {
+        if (receiver.get() == COMMAND_NEEDS_FINALIZATION) {
+            return false
+        }
+        transmitter.set(command.id)
+        return true
+    }
+
+    /**
+     * Tell the Quest where it is on the field.
+     */
+    fun resetPosition(pose2d: Pose2d) {
+        questResetPose.set(
+            doubleArrayOf(
+                pose2d.x,
+                pose2d.y,
+                pose2d.rotation.degrees,
+            )
+        )
+        sendCommand(QuestCommand.PoseReset)
+    }
+
+    /**
+     * Clean up the current commands so a new one could be sent.
+     */
+    fun finalizeCommands() {
+        if (receiver.get() == COMMAND_NEEDS_FINALIZATION) {
+            transmitter.set(QuestCommand.None.id)
+        }
+    }
+
+    private val oculusYaw: Float
+        // Get the yaw Euler angle of the headset
+        get() = questEulerAngles.get()[1]
+
+    private val questNavTranslation: Translation2d
+        get() {
+            val questNavPosition = questPosition.get()
+            return Translation2d(questNavPosition[2].toDouble(), -questNavPosition[0].toDouble())
+        }
+
+    private val questNavPose: Pose2d
+        get() {
+            val oculusPositionCompensated = questNavTranslation.minus(Translation2d(0.0, 0.1651)) // 6.5
+            return Pose2d(oculusPositionCompensated, Rotation2d.fromDegrees(oculusYaw.toDouble()))
+        }
+}

--- a/src/main/kotlin/com/frcteam3636/frc2025/utils/swerve/Swerve.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/utils/swerve/Swerve.kt
@@ -5,6 +5,8 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics
 import edu.wpi.first.math.kinematics.SwerveModuleState
 import edu.wpi.first.units.Units.MetersPerSecond
+import edu.wpi.first.units.Units.RadiansPerSecond
+import edu.wpi.first.units.measure.AngularVelocity
 import edu.wpi.first.units.measure.LinearVelocity
 
 enum class DrivetrainCorner {
@@ -81,6 +83,12 @@ var SwerveModuleState.speed: LinearVelocity
         speedMetersPerSecond = value.`in`(MetersPerSecond)
     }
 
-/** This swerve module state as a Translation2d. */
+/** This swerve module state as a `Translation2d`. */
 val SwerveModuleState.translation2dPerSecond: Translation2d
     get() = Translation2d(speedMetersPerSecond, angle)
+
+val ChassisSpeeds.translation2dPerSecond: Translation2d
+    get() = Translation2d(vxMetersPerSecond, vyMetersPerSecond)
+
+val ChassisSpeeds.angularVelocity: AngularVelocity
+    get() = RadiansPerSecond.of(omegaRadiansPerSecond)


### PR DESCRIPTION
Adds a new localization strategy based on QuestNav. The robot automatically switches to this strategy when a device running QuestNav is connected and has been calibrated using a high-quality April Tag reading.