### PR TITLE
feat(PoseEstimator): add MegaTag2 algorithm to limelight pose provider

### DIFF
--- a/annotation/src/main/kotlin/org/team9432/annotation/LogTableUtils.kt
+++ b/annotation/src/main/kotlin/org/team9432/annotation/LogTableUtils.kt
@@ -37,7 +37,7 @@ object LogTableUtils {
 
     fun <E : Enum<E>> LogTable.kPut(key: String, value: E) = put(key, value)
 
-    fun <U : Unit> LogTable.kPut(key: String, value: Measure<U>) = put(key, value)
+    fun <M : Measure<U>, U : Unit> LogTable.kPut(key: String, value: M) = put(key, value)
 
     fun LogTable.kPut(key: String, value: BooleanArray) = put(key, value)
 

--- a/annotation/src/main/kotlin/org/team9432/annotation/LogTableUtils.kt
+++ b/annotation/src/main/kotlin/org/team9432/annotation/LogTableUtils.kt
@@ -80,7 +80,7 @@ object LogTableUtils {
 
     fun <E : Enum<E>> LogTable.kGet(key: String, defaultValue: E): E = get(key, defaultValue)
 
-    fun <M : Measure<U>, U : Unit> LogTable.kGet(key: String, defaultValue: Measure<U>): Measure<U> =
+    fun <M : Measure<U>, U : Unit> LogTable.kGet(key: String, defaultValue: M): M =
         get(key, defaultValue)
 
     fun LogTable.kGet(key: String, defaultValue: BooleanArray): BooleanArray = get(key, defaultValue)

--- a/annotation/src/main/kotlin/org/team9432/annotation/LogTableUtils.kt
+++ b/annotation/src/main/kotlin/org/team9432/annotation/LogTableUtils.kt
@@ -80,7 +80,8 @@ object LogTableUtils {
 
     fun <E : Enum<E>> LogTable.kGet(key: String, defaultValue: E): E = get(key, defaultValue)
 
-    fun <U : Unit> LogTable.kGet(key: String, defaultValue: Measure<U>): Measure<U> = get(key, defaultValue)
+    fun <M : Measure<U>, U : Unit> LogTable.kGet(key: String, defaultValue: Measure<U>): Measure<U> =
+        get(key, defaultValue)
 
     fun LogTable.kGet(key: String, defaultValue: BooleanArray): BooleanArray = get(key, defaultValue)
 

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/AbsolutePose.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/AbsolutePose.kt
@@ -143,11 +143,14 @@ class LimelightPoseProvider(
     companion object {
         /**
          * The acceptable distance for a single-April-Tag reading.
+         *
+         * This is a somewhat conservative limit, but it is only applied when using the old MegaTag v1 algorithm.
+         * It's possible it could be increased if it's too restrictive.
          */
         private val MAX_SINGLE_TAG_DISTANCE = Meters.of(3.0)!!
 
         /**
-         * The acceptable ambiguity for a single-tag reading.
+         * The acceptable ambiguity for a single-tag reading on MegaTag v1.
          */
         private const val AMBIGUITY_THRESHOLD = 0.7
 

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Drivetrain.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Drivetrain.kt
@@ -23,7 +23,10 @@ import com.pathplanner.lib.controllers.PPHolonomicDriveController
 import com.pathplanner.lib.pathfinding.Pathfinding
 import edu.wpi.first.math.VecBuilder
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator
-import edu.wpi.first.math.geometry.*
+import edu.wpi.first.math.geometry.Pose2d
+import edu.wpi.first.math.geometry.Rotation2d
+import edu.wpi.first.math.geometry.Transform2d
+import edu.wpi.first.math.geometry.Translation2d
 import edu.wpi.first.math.kinematics.ChassisSpeeds
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics
 import edu.wpi.first.math.kinematics.SwerveModuleState
@@ -41,7 +44,6 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController
 import org.littletonrobotics.junction.Logger
 import java.util.*
 import kotlin.jvm.optionals.getOrNull
-import kotlin.math.PI
 import kotlin.math.abs
 
 /** A singleton object representing the drivetrain. */
@@ -60,20 +62,25 @@ object Drivetrain : Subsystem, Sendable {
     private var questNavCalibrated = false
 
     private val absolutePoseIOs = mapOf(
-        "Limelight" to LimelightPoseProvider("limelight"),
+        "Limelight" to LimelightPoseProvider(
+            "limelight",
+            algorithm = LimelightAlgorithm.MegaTag2 { inputs }
+        ),
     ).mapValues { Pair(it.value, AbsolutePoseProviderInputs()) }
 
     /** Helper for converting a desired drivetrain velocity into the speeds and angles for each swerve module */
     private val kinematics =
         SwerveDriveKinematics(
-            *Constants.MODULE_POSITIONS.map(Pose2d::getTranslation).toTypedArray()
+            *Constants.MODULE_POSITIONS
+                .map { it.translation }
+                .toTypedArray()
         )
 
     /** Helper for estimating the location of the drivetrain on the field */
     private val poseEstimator =
         SwerveDrivePoseEstimator(
             kinematics, // swerve drive kinematics
-            inputs.gyroRotation.toRotation2d(), // initial gyro rotation
+            inputs.gyroRotation, // initial gyro rotation
             inputs.measuredPositions.toTypedArray(), // initial module positions
             Pose2d(), // initial pose
             VecBuilder.fill(0.05, 0.05, Units.degreesToRadians(5.0)),
@@ -131,18 +138,18 @@ object Drivetrain : Subsystem, Sendable {
             sensorIO.updateInputs(inputs)
             Logger.processInputs("Drivetrain/Absolute Pose/$name", inputs)
 
+            Logger.recordOutput("Drivetrain/Absolute Pose/$name/Has Measurement", inputs.measurement != null)
             inputs.measurement?.let {
                 poseEstimator.addAbsolutePoseMeasurement(it)
                 Logger.recordOutput("Drivetrain/Absolute Pose/$name/Measurement", it)
                 Logger.recordOutput("Drivetrain/Last Added Pose", it.pose)
                 Logger.recordOutput("Drivetrain/Absolute Pose/$name/Pose", it.pose)
             }
-            Logger.recordOutput("Drivetrain/Absolute Pose/$name/Has High Quality Reading", sensorIO.hasHighQualityReading)
         }
 
         // Use the new measurements to update the pose estimator
         poseEstimator.update(
-            inputs.gyroRotation.toRotation2d(),
+            inputs.gyroRotation,
             inputs.measuredPositions.toTypedArray()
         )
 
@@ -207,11 +214,11 @@ object Drivetrain : Subsystem, Sendable {
             return Pose2d(
                 estimated.x,
                 estimated.y,
-                inputs.gyroRotation.toRotation2d(),
+                inputs.gyroRotation,
             )
         }
         private set(value) = poseEstimator.resetPosition(
-            inputs.gyroRotation.toRotation2d(),
+            inputs.gyroRotation,
             inputs.measuredPositions.toTypedArray(),
             value
         )
@@ -221,7 +228,7 @@ object Drivetrain : Subsystem, Sendable {
      */
     private fun updateQuestNavOrigin() {
         val hasHighQualityData = absolutePoseIOs.values.any {
-            it.first.hasHighQualityReading
+            it.second.measurement != null
         }
         if (!hasHighQualityData || isMoving) return
         questNavLocalizer.resetPose(poseEstimator.estimatedPosition)
@@ -230,7 +237,7 @@ object Drivetrain : Subsystem, Sendable {
 
     override fun initSendable(builder: SendableBuilder) {
         builder.setSmartDashboardType(ElasticWidgets.SwerveDrive.widgetName)
-        builder.addDoubleProperty("Robot Angle", { inputs.gyroRotation.toRotation2d().radians }, null)
+        builder.addDoubleProperty("Robot Angle", { inputs.gyroRotation.radians }, null)
 
         builder.addDoubleProperty("Front Left Angle", { io.modules.frontLeft.state.angle.radians }, null)
         builder.addDoubleProperty("Front Left Velocity", { io.modules.frontLeft.state.speedMetersPerSecond }, null)
@@ -257,7 +264,7 @@ object Drivetrain : Subsystem, Sendable {
                 translationInput.x * FREE_SPEED.baseUnitMagnitude() * TRANSLATION_SENSITIVITY,
                 translationInput.y * FREE_SPEED.baseUnitMagnitude() * TRANSLATION_SENSITIVITY,
                 -rotationInput.y * TAU * ROTATION_SENSITIVITY,
-                inputs.gyroRotation.toRotation2d()
+                inputs.gyroRotation
             )
         }
     }
@@ -303,7 +310,7 @@ object Drivetrain : Subsystem, Sendable {
                 translationInput.x * FREE_SPEED.baseUnitMagnitude() * TRANSLATION_SENSITIVITY,
                 translationInput.y * FREE_SPEED.baseUnitMagnitude() * TRANSLATION_SENSITIVITY,
                 -magnitude,
-                inputs.gyroRotation.toRotation2d()
+                inputs.gyroRotation
             )
         }, {
             // Might be worth testing this but AdvantageScope seems to ignore `null`s
@@ -314,8 +321,8 @@ object Drivetrain : Subsystem, Sendable {
     fun zeroGyro() {
         // Tell the gyro that the robot is facing the other alliance.
         val zeroPos = when (DriverStation.getAlliance().getOrNull()) {
-            DriverStation.Alliance.Blue -> Rotation3d()
-            else -> Rotation3d(0.0, 0.0, PI)
+            DriverStation.Alliance.Blue -> Rotation2d.kZero
+            else -> Rotation2d.k180deg
         }
         io.setGyro(zeroPos)
     }

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/DrivetrainIO.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/DrivetrainIO.kt
@@ -5,17 +5,19 @@ import com.frcteam3636.frc2025.Pigeon2
 import com.frcteam3636.frc2025.Robot
 import com.frcteam3636.frc2025.utils.swerve.PerCorner
 import com.studica.frc.AHRS
-import edu.wpi.first.math.geometry.Rotation3d
+import edu.wpi.first.math.geometry.Rotation2d
 import edu.wpi.first.math.kinematics.SwerveModulePosition
 import edu.wpi.first.math.kinematics.SwerveModuleState
+import edu.wpi.first.units.Units.DegreesPerSecond
 import org.team9432.annotation.Logged
 
 @Logged
 open class DrivetrainInputs {
-    var gyroRotation = Rotation3d()
+    var gyroRotation = Rotation2d()
+    var gyroVelocity = DegreesPerSecond.zero()!!
+    var gyroConnected = true
     var measuredStates = PerCorner.generate { SwerveModuleState() }
     var measuredPositions = PerCorner.generate { SwerveModulePosition() }
-    var gyroConnected = true
 }
 
 
@@ -29,12 +31,13 @@ abstract class DrivetrainIO {
         modules.forEach(SwerveModule::periodic)
 
         inputs.gyroRotation = gyro.rotation
+        inputs.gyroVelocity = gyro.velocity
+        inputs.gyroConnected = gyro.connected
         inputs.measuredStates = modules.map { it.state }
         inputs.measuredPositions = modules.map { it.position }
-        inputs.gyroConnected = gyro.connected
     }
 
-    fun setGyro(rotation: Rotation3d) {
+    fun setGyro(rotation: Rotation2d) {
         gyro.rotation = rotation
     }
 

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/DrivetrainIO.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/DrivetrainIO.kt
@@ -3,6 +3,7 @@ package com.frcteam3636.frc2025.subsystems.drivetrain
 import com.frcteam3636.frc2025.CTREDeviceId
 import com.frcteam3636.frc2025.Pigeon2
 import com.frcteam3636.frc2025.Robot
+import com.frcteam3636.frc2025.utils.math.TAU
 import com.frcteam3636.frc2025.utils.swerve.PerCorner
 import com.studica.frc.AHRS
 import edu.wpi.first.math.geometry.Rotation2d
@@ -38,6 +39,7 @@ abstract class DrivetrainIO {
     }
 
     fun setGyro(rotation: Rotation2d) {
+        assert(rotation.radians in 0.0..TAU)
         gyro.rotation = rotation
     }
 

--- a/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Gyro.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/subsystems/drivetrain/Gyro.kt
@@ -6,8 +6,11 @@ import com.frcteam3636.frc2025.Robot
 import com.frcteam3636.frc2025.utils.swerve.PerCorner
 import com.frcteam3636.frc2025.utils.swerve.translation2dPerSecond
 import com.studica.frc.AHRS
-import edu.wpi.first.math.geometry.Rotation3d
+import edu.wpi.first.math.geometry.Rotation2d
 import edu.wpi.first.math.geometry.Translation2d
+import edu.wpi.first.units.Units.DegreesPerSecond
+import edu.wpi.first.units.Units.RadiansPerSecond
+import edu.wpi.first.units.measure.AngularVelocity
 import org.littletonrobotics.junction.Logger
 import kotlin.math.sign
 
@@ -16,7 +19,12 @@ interface Gyro {
      * The current rotation of the robot.
      * This can be set to a different value to change the gyro's offset.
      */
-    var rotation: Rotation3d
+    var rotation: Rotation2d
+
+    /**
+     * The rotational velocity of the robot on its yaw axis.
+     */
+    val velocity: AngularVelocity
 
     /** Whether the gyro is connected. */
     val connected: Boolean
@@ -26,45 +34,48 @@ interface Gyro {
 
 class GyroNavX(private val ahrs: AHRS) : Gyro {
 
-    private var offset: Rotation3d = Rotation3d()
+    private var offset = Rotation2d()
 
     init {
         Logger.recordOutput("NavXGyro/Offset", offset)
     }
 
-    override var rotation: Rotation3d
-        get() = offset + ahrs.rotation3d
+    override var rotation: Rotation2d
+        get() = offset + ahrs.rotation2d
         set(goal) {
-            offset = goal - ahrs.rotation3d
+            offset = goal - ahrs.rotation2d
             Logger.recordOutput("NavXGyro/Offset", offset)
         }
+
+    override val velocity: AngularVelocity
+        get() = DegreesPerSecond.of(ahrs.rate)
 
     override val connected
         get() = ahrs.isConnected
 }
 
 class GyroPigeon(private val pigeon: Pigeon2) : Gyro {
-
-    private var offset: Rotation3d = Rotation3d()
-
     init {
-        Logger.recordOutput("PigeonGyro/Offset", offset)
-        BaseStatusSignal.setUpdateFrequencyForAll(100.0, pigeon.yaw, pigeon.pitch, pigeon.roll);
+        BaseStatusSignal.setUpdateFrequencyForAll(100.0, pigeon.yaw, pigeon.pitch, pigeon.roll)
     }
 
-    override var rotation: Rotation3d
-        get() = offset + pigeon.rotation3d
+    override var rotation: Rotation2d
+        get() = pigeon.rotation2d
         set(goal) {
-            offset = goal - pigeon.rotation3d
-            Logger.recordOutput("PigeonGyro/Offset", offset)
+            pigeon.setYaw(goal.measure)
         }
+
+    override val velocity: AngularVelocity
+        get() = pigeon.angularVelocityZWorld.value
 
     override val connected
         get() = pigeon.yaw.status.isOK
 }
 
 class GyroSim(private val modules: PerCorner<SwerveModule>) : Gyro {
-    override var rotation = Rotation3d()
+    override var rotation = Rotation2d()
+    override var velocity: AngularVelocity = RadiansPerSecond.zero()
+        private set
     override val connected = true
 
     override fun periodic() {
@@ -78,6 +89,7 @@ class GyroSim(private val modules: PerCorner<SwerveModule>) : Gyro {
             sign(rotationalVelocities.frontLeft.y) * rotationalVelocities.frontLeft.norm /
                     Drivetrain.Constants.MODULE_POSITIONS.frontLeft.translation.norm
 
-        rotation += Rotation3d(0.0, 0.0, yawVelocity) * Robot.period
+        velocity = RadiansPerSecond.of(yawVelocity)
+        rotation += Rotation2d(yawVelocity) * Robot.period
     }
 }

--- a/src/main/kotlin/com/frcteam3636/frc2025/utils/LimelightHelpers.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/utils/LimelightHelpers.kt
@@ -1,5 +1,7 @@
 //LimelightHelpers v1.10 (REQUIRES LLOS 2024.9.1 OR LATER)
 
+@file:Suppress("unused")
+
 package com.frcteam3636.frc2025.utils
 
 import com.fasterxml.jackson.annotation.JsonFormat
@@ -13,6 +15,8 @@ import edu.wpi.first.networktables.DoubleArrayEntry
 import edu.wpi.first.networktables.NetworkTable
 import edu.wpi.first.networktables.NetworkTableEntry
 import edu.wpi.first.networktables.NetworkTableInstance
+import edu.wpi.first.units.Units.Meters
+import edu.wpi.first.units.measure.Distance
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
@@ -164,7 +168,8 @@ object LimelightHelpers {
                 val distToCamera = poseArray[baseIndex + 4]
                 val distToRobot = poseArray[baseIndex + 5]
                 val ambiguity = poseArray[baseIndex + 6]
-                rawFiducials[i] = RawFiducial(id, txnc, tync, ta, distToCamera, distToRobot, ambiguity)
+                rawFiducials[i] =
+                    RawFiducial(id, txnc, tync, ta, Meters.of(distToCamera), Meters.of(distToRobot), ambiguity)
             }
         }
 
@@ -208,7 +213,8 @@ object LimelightHelpers {
             val distToRobot = extractArrayEntry(rawFiducialArray, baseIndex + 5)
             val ambiguity = extractArrayEntry(rawFiducialArray, baseIndex + 6)
 
-            rawFiducials[i] = RawFiducial(id, txnc, tync, ta, distToCamera, distToRobot, ambiguity)
+            rawFiducials[i] =
+                RawFiducial(id, txnc, tync, ta, Meters.of(distToCamera), Meters.of(distToRobot), ambiguity)
         }
 
         return rawFiducials
@@ -288,14 +294,14 @@ object LimelightHelpers {
         System.out.printf("Is MegaTag2: %b%n", pose.isMegaTag2)
         println()
 
-        if (pose.rawFiducials == null || pose.rawFiducials!!.size == 0) {
+        if (pose.rawFiducials.isEmpty()) {
             println("No RawFiducials data available.")
             return
         }
 
         println("Raw Fiducials Details:")
-        for (i in pose.rawFiducials!!.indices) {
-            val fiducial = pose.rawFiducials!![i]
+        for (i in pose.rawFiducials.indices) {
+            val fiducial = pose.rawFiducials[i]
             System.out.printf(" Fiducial #%d:%n", i + 1)
             System.out.printf("  ID: %d%n", fiducial!!.id)
             System.out.printf("  TXNC: %.2f%n", fiducial.txnc)
@@ -309,7 +315,7 @@ object LimelightHelpers {
     }
 
     fun validPoseEstimate(pose: PoseEstimate?): Boolean {
-        return pose?.rawFiducials != null && pose.rawFiducials!!.size != 0
+        return pose?.rawFiducials != null && pose.rawFiducials.isNotEmpty()
     }
 
     fun getLimelightNTTable(tableName: String?): NetworkTable {
@@ -1420,16 +1426,16 @@ object LimelightHelpers {
         txnc: Double,
         tync: Double,
         ta: Double,
-        distToCamera: Double,
-        distToRobot: Double,
-        ambiguity: Double
+        distToCamera: Distance,
+        distToRobot: Distance,
+        ambiguity: Double,
     ) {
         var id: Int = 0
         var txnc: Double = 0.0
         var tync: Double = 0.0
         var ta: Double = 0.0
-        var distToCamera: Double = 0.0
-        var distToRobot: Double = 0.0
+        var distToCamera: Distance = Meters.zero()
+        var distToRobot: Distance = Meters.zero()
         var ambiguity: Double = 0.0
 
 
@@ -1496,7 +1502,7 @@ object LimelightHelpers {
         var avgTagDist: Double
         var avgTagArea: Double
 
-        var rawFiducials: Array<RawFiducial?>?
+        var rawFiducials: Array<RawFiducial?>
         var isMegaTag2: Boolean
 
         /**
@@ -1517,7 +1523,7 @@ object LimelightHelpers {
         constructor(
             pose: Pose2d, timestampSeconds: Double, latency: Double,
             tagCount: Int, tagSpan: Double, avgTagDist: Double,
-            avgTagArea: Double, rawFiducials: Array<RawFiducial?>?, isMegaTag2: Boolean
+            avgTagArea: Double, rawFiducials: Array<RawFiducial?>, isMegaTag2: Boolean
         ) {
             this.pose = pose
             this.timestampSeconds = timestampSeconds

--- a/src/main/kotlin/com/frcteam3636/frc2025/utils/math/Math.kt
+++ b/src/main/kotlin/com/frcteam3636/frc2025/utils/math/Math.kt
@@ -1,9 +1,6 @@
 package com.frcteam3636.frc2025.utils.math
 
-import edu.wpi.first.math.geometry.Rotation2d
 import edu.wpi.first.math.geometry.Translation2d
-import edu.wpi.first.units.Units.Radians
-import edu.wpi.first.units.measure.Angle
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
@@ -17,5 +14,3 @@ fun Translation2d.fromPolar(magnitude: Double, angle: Double): Translation2d {
 fun Translation2d.dot(other: Translation2d): Double {
     return x * other.x + y * other.y
 }
-
-val Rotation2d.angle: Angle get() = Radians.of(radians)


### PR DESCRIPTION
Adds MegaTag2 support to the Limelight pose provider. Additionally, this PR switches the Pigeon zeroing mechanism to use the builtin `setYaw` function and also makes gyros return a `Rotation2d` instead of a `Rotation3d` because we were already converting all our reading to the former type anyway.

It also updates the annotations library to support 2025 WPILib units.